### PR TITLE
set_bar fix for green/blue channel swapped dot3k

### DIFF
--- a/python/library/dot3k/backlight.py
+++ b/python/library/dot3k/backlight.py
@@ -1,4 +1,6 @@
-import sn3218, colorsys, math
+import math
+import colorsys
+import sn3218
 
 LED_R_R = 0x00
 LED_R_G = 0x01
@@ -31,10 +33,11 @@ for i in range(9, 18):
 
 sn3218.enable()
 
+
 def use_rbg():
     """
     Swaps the Green and Blue channels on the LED backlight
-  
+
     Use if you have a first batch Display-o-Tron 3K
     """
     global LED_R_G, LED_R_B
@@ -45,10 +48,11 @@ def use_rbg():
     (LED_M_G, LED_M_B) = (LED_M_B, LED_M_G)
     (LED_L_G, LED_L_B) = (LED_L_B, LED_L_G)
 
+
 def set_graph(value):
     """
     Lights a number of bargraph LEDs depending upon value
-    
+
     Args:
         value (float): percentage between 0.0 and 1.0
     """
@@ -59,7 +63,7 @@ def set_graph(value):
 
     for i in range(9):
         leds[9 + i] = 0
-    
+
     lit = int(math.floor(value))
     for i in range(lit):
         leds[9 + i] = 255
@@ -70,104 +74,114 @@ def set_graph(value):
 
     update()
 
+
 def set(index, value):
     """
     Set a specific LED to a value
-    
+
     Args:
         index (int): index of the LED from 0 to 18
         value (int): brightness value from 0 to 255
     """
     leds[index] = value
+    update()
+
 
 def set_bar(index, value):
     """
     Set a value or values to one or more LEDs
-    
+
     Args:
         index (int): starting index
-        value (int or list): a single int, or list of brightness values from 0 to 255
+        value (int or list): a single int,
+        or list of brightness values from 0 to 255
     """
     if isinstance(value, int):
-        set(LED_L_B + 1 + index, value)
+        set(LED_R_R + 9 + (index % 9), value)
     if isinstance(value, list):
         for i, v in enumerate(value):
-            set(LED_L_B + 1 + ((index + i)%9), v)
+            set(LED_R_R + 9 + ((index + i) % 9), v)
     update()
-    
-def hue_to_rgb( hue ):
+
+
+def hue_to_rgb(hue):
     """
     Converts a hue to RGB brightness values
-    
+
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
     rgb = colorsys.hsv_to_rgb(hue, 1.0, 1.0)
 
-    return [int(rgb[0]*255), int(rgb[1]*255), int(rgb[2]*255)]
+    return [int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255)]
 
-def hue( hue ):
+
+def hue(hue):
     """
     Sets the backlight LEDs to supplied hue
-    
+
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
-    col_rgb = hue_to_rgb( hue )
-    rgb( col_rgb[0], col_rgb[1], col_rgb[2] )
+    col_rgb = hue_to_rgb(hue)
+    rgb(col_rgb[0], col_rgb[1], col_rgb[2])
 
 
-def sweep( hue, range = 0.08 ):
+def sweep(hue, range=0.08):
     """
     Sets the backlight LEDs to a gradient centered on supplied hue
-    
+
     Supplying zero to range would be the same as hue()
-    
+
     Args:
         hue (float): hue value between 0.0 and 1.0
         range (float): range value to deviate the left and right hue
     """
-    left_hue( (hue-range) % 1 )
-    mid_hue( hue )
-    right_hue( (hue+range) % 1 )
+    left_hue((hue - range) % 1)
+    mid_hue(hue)
+    right_hue((hue + range) % 1)
 
-def left_hue( hue ):
+
+def left_hue(hue):
     """
     Set the left backlight to supplied hue
-    
+
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
-    col_rgb = hue_to_rgb( hue )
-    left_rgb( col_rgb[0], col_rgb[1], col_rgb[2] )
+    col_rgb = hue_to_rgb(hue)
+    left_rgb(col_rgb[0], col_rgb[1], col_rgb[2])
     update()
 
-def mid_hue( hue ):
+
+def mid_hue(hue):
     """
     Set the middle backlight to supplied hue
-    
+
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
-    col_rgb = hue_to_rgb( hue )
-    mid_rgb( col_rgb[0], col_rgb[1], col_rgb[2] )
+    col_rgb = hue_to_rgb(hue)
+    mid_rgb(col_rgb[0], col_rgb[1], col_rgb[2])
     update()
 
-def right_hue( hue ):
+
+def right_hue(hue):
     """
     Set the right backlight to supplied hue
-    
+
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
-    col_rgb = hue_to_rgb( hue )
-    right_rgb( col_rgb[0], col_rgb[1], col_rgb[2] )
+    col_rgb = hue_to_rgb(hue)
+    right_rgb(col_rgb[0], col_rgb[1], col_rgb[2])
     update()
 
-def left_rgb( r, g, b ):
+
+def left_rgb(r, g, b):
     """
     Set the left backlight to supplied r, g, b colour
-    
+
     Args:
         r (int): red value between 0 and 255
         g (int): green value between 0 and 255
@@ -178,10 +192,11 @@ def left_rgb( r, g, b ):
     set(LED_L_G, g)
     update()
 
-def mid_rgb( r, g, b ):
+
+def mid_rgb(r, g, b):
     """
     Set the middle backlight to supplied r, g, b colour
-    
+
     Args:
         r (int): red value between 0 and 255
         g (int): green value between 0 and 255
@@ -192,10 +207,11 @@ def mid_rgb( r, g, b ):
     set(LED_M_G, g)
     update()
 
-def right_rgb( r, g, b ):
+
+def right_rgb(r, g, b):
     """
     Set the right backlight to supplied r, g, b colour
-    
+
     Args:
         r (int): red value between 0 and 255
         g (int): green value between 0 and 255
@@ -206,24 +222,27 @@ def right_rgb( r, g, b ):
     set(LED_R_G, g)
     update()
 
-def rgb( r, g, b ):
+
+def rgb(r, g, b):
     """
     Sets all backlights to supplied r, g, b colour
-    
+
     Args:
         r (int): red value between 0 and 255
         g (int): green value between 0 and 255
         b (int): blue value between 0 and 255
     """
-    left_rgb( r, g, b )
-    mid_rgb( r, g, b )
-    right_rgb( r, g, b)
-    
+    left_rgb(r, g, b)
+    mid_rgb(r, g, b)
+    right_rgb(r, g, b)
+
+
 def off():
     """
     Turns off the backlight.
     """
-    rgb(0,0,0)
+    rgb(0, 0, 0)
+
 
 def update():
     """

--- a/python/library/dot3k/backlight.py
+++ b/python/library/dot3k/backlight.py
@@ -90,10 +90,10 @@ def set_bar(index, value):
         value (int or list): a single int, or list of brightness values from 0 to 255
     """
     if isinstance(value, int):
-        set(LED_R_R + 1 + (index%9), value)
+        set(LED_R_R + 9 + (index%9), value)
     if isinstance(value, list):
         for i, v in enumerate(value):
-            set(LED_R_R + 1 + ((index + i)%9), v)
+            set(LED_R_R + 9 + ((index + i)%9), v)
     update()
     
 def hue_to_rgb( hue ):

--- a/python/library/dot3k/backlight.py
+++ b/python/library/dot3k/backlight.py
@@ -1,6 +1,4 @@
-import math
-import colorsys
-import sn3218
+import sn3218, colorsys, math
 
 LED_R_R = 0x00
 LED_R_G = 0x01
@@ -33,11 +31,10 @@ for i in range(9, 18):
 
 sn3218.enable()
 
-
 def use_rbg():
     """
     Swaps the Green and Blue channels on the LED backlight
-
+  
     Use if you have a first batch Display-o-Tron 3K
     """
     global LED_R_G, LED_R_B
@@ -48,11 +45,10 @@ def use_rbg():
     (LED_M_G, LED_M_B) = (LED_M_B, LED_M_G)
     (LED_L_G, LED_L_B) = (LED_L_B, LED_L_G)
 
-
 def set_graph(value):
     """
     Lights a number of bargraph LEDs depending upon value
-
+    
     Args:
         value (float): percentage between 0.0 and 1.0
     """
@@ -63,7 +59,7 @@ def set_graph(value):
 
     for i in range(9):
         leds[9 + i] = 0
-
+    
     lit = int(math.floor(value))
     for i in range(lit):
         leds[9 + i] = 255
@@ -74,114 +70,104 @@ def set_graph(value):
 
     update()
 
-
 def set(index, value):
     """
     Set a specific LED to a value
-
+    
     Args:
         index (int): index of the LED from 0 to 18
         value (int): brightness value from 0 to 255
     """
     leds[index] = value
-    update()
-
 
 def set_bar(index, value):
     """
     Set a value or values to one or more LEDs
-
+    
     Args:
         index (int): starting index
-        value (int or list): a single int,
-        or list of brightness values from 0 to 255
+        value (int or list): a single int, or list of brightness values from 0 to 255
     """
     if isinstance(value, int):
-        set(LED_R_R + 9 + (index % 9), value)
+        set(LED_L_B + 1 + index, value)
     if isinstance(value, list):
         for i, v in enumerate(value):
-            set(LED_R_R + 9 + ((index + i) % 9), v)
+            set(LED_L_B + 1 + ((index + i)%9), v)
     update()
-
-
-def hue_to_rgb(hue):
+    
+def hue_to_rgb( hue ):
     """
     Converts a hue to RGB brightness values
-
+    
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
     rgb = colorsys.hsv_to_rgb(hue, 1.0, 1.0)
 
-    return [int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255)]
+    return [int(rgb[0]*255), int(rgb[1]*255), int(rgb[2]*255)]
 
-
-def hue(hue):
+def hue( hue ):
     """
     Sets the backlight LEDs to supplied hue
-
+    
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
-    col_rgb = hue_to_rgb(hue)
-    rgb(col_rgb[0], col_rgb[1], col_rgb[2])
+    col_rgb = hue_to_rgb( hue )
+    rgb( col_rgb[0], col_rgb[1], col_rgb[2] )
 
 
-def sweep(hue, range=0.08):
+def sweep( hue, range = 0.08 ):
     """
     Sets the backlight LEDs to a gradient centered on supplied hue
-
+    
     Supplying zero to range would be the same as hue()
-
+    
     Args:
         hue (float): hue value between 0.0 and 1.0
         range (float): range value to deviate the left and right hue
     """
-    left_hue((hue - range) % 1)
-    mid_hue(hue)
-    right_hue((hue + range) % 1)
+    left_hue( (hue-range) % 1 )
+    mid_hue( hue )
+    right_hue( (hue+range) % 1 )
 
-
-def left_hue(hue):
+def left_hue( hue ):
     """
     Set the left backlight to supplied hue
-
+    
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
-    col_rgb = hue_to_rgb(hue)
-    left_rgb(col_rgb[0], col_rgb[1], col_rgb[2])
+    col_rgb = hue_to_rgb( hue )
+    left_rgb( col_rgb[0], col_rgb[1], col_rgb[2] )
     update()
 
-
-def mid_hue(hue):
+def mid_hue( hue ):
     """
     Set the middle backlight to supplied hue
-
+    
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
-    col_rgb = hue_to_rgb(hue)
-    mid_rgb(col_rgb[0], col_rgb[1], col_rgb[2])
+    col_rgb = hue_to_rgb( hue )
+    mid_rgb( col_rgb[0], col_rgb[1], col_rgb[2] )
     update()
 
-
-def right_hue(hue):
+def right_hue( hue ):
     """
     Set the right backlight to supplied hue
-
+    
     Args:
         hue (float): hue value between 0.0 and 1.0
     """
-    col_rgb = hue_to_rgb(hue)
-    right_rgb(col_rgb[0], col_rgb[1], col_rgb[2])
+    col_rgb = hue_to_rgb( hue )
+    right_rgb( col_rgb[0], col_rgb[1], col_rgb[2] )
     update()
 
-
-def left_rgb(r, g, b):
+def left_rgb( r, g, b ):
     """
     Set the left backlight to supplied r, g, b colour
-
+    
     Args:
         r (int): red value between 0 and 255
         g (int): green value between 0 and 255
@@ -192,11 +178,10 @@ def left_rgb(r, g, b):
     set(LED_L_G, g)
     update()
 
-
-def mid_rgb(r, g, b):
+def mid_rgb( r, g, b ):
     """
     Set the middle backlight to supplied r, g, b colour
-
+    
     Args:
         r (int): red value between 0 and 255
         g (int): green value between 0 and 255
@@ -207,11 +192,10 @@ def mid_rgb(r, g, b):
     set(LED_M_G, g)
     update()
 
-
-def right_rgb(r, g, b):
+def right_rgb( r, g, b ):
     """
     Set the right backlight to supplied r, g, b colour
-
+    
     Args:
         r (int): red value between 0 and 255
         g (int): green value between 0 and 255
@@ -222,27 +206,24 @@ def right_rgb(r, g, b):
     set(LED_R_G, g)
     update()
 
-
-def rgb(r, g, b):
+def rgb( r, g, b ):
     """
     Sets all backlights to supplied r, g, b colour
-
+    
     Args:
         r (int): red value between 0 and 255
         g (int): green value between 0 and 255
         b (int): blue value between 0 and 255
     """
-    left_rgb(r, g, b)
-    mid_rgb(r, g, b)
-    right_rgb(r, g, b)
-
-
+    left_rgb( r, g, b )
+    mid_rgb( r, g, b )
+    right_rgb( r, g, b)
+    
 def off():
     """
     Turns off the backlight.
     """
-    rgb(0, 0, 0)
-
+    rgb(0,0,0)
 
 def update():
     """

--- a/python/library/dot3k/backlight.py
+++ b/python/library/dot3k/backlight.py
@@ -79,6 +79,7 @@ def set(index, value):
         value (int): brightness value from 0 to 255
     """
     leds[index] = value
+    update()
 
 def set_bar(index, value):
     """
@@ -89,10 +90,10 @@ def set_bar(index, value):
         value (int or list): a single int, or list of brightness values from 0 to 255
     """
     if isinstance(value, int):
-        set(LED_L_B + 1 + index, value)
+        set(LED_R_R + 1 + (index%9), value)
     if isinstance(value, list):
         for i, v in enumerate(value):
-            set(LED_L_B + 1 + ((index + i)%9), v)
+            set(LED_R_R + 1 + ((index + i)%9), v)
     update()
     
 def hue_to_rgb( hue ):


### PR DESCRIPTION
this set_bar tweak uses a channel not impacted by use_rbg() and therefore suitable for both G/B swapped dot3k and regular, avoiding an index offset of 1 for the inverted channel version.

In addition, when supplying a single integer rather than a list, the index will wrap around similarly to how the function is applied with a list. This is particularly useful as this means that the LED index 9-17 will correspond to their index when using the 'set' function.

last change, to 'set', ensures that the buffer is committed to the backlight.