### PR TITLE
Fix crash in Python 3.x with clock plugin

### DIFF
--- a/python/examples/plugins/clock.py
+++ b/python/examples/plugins/clock.py
@@ -43,9 +43,9 @@ class Clock(MenuOption):
             self.backlight.rgb(r, g, b)
 
     def update_options(self):
-        self.set_option('Clock', 'dim', self.dim_hour)
-        self.set_option('Clock', 'bright', self.bright_hour)
-        self.set_option('Clock', 'binary', self.binary)
+        self.set_option('Clock', 'dim', str(self.dim_hour))
+        self.set_option('Clock', 'bright', str(self.bright_hour))
+        self.set_option('Clock', 'binary', str(self.binary))
 
     def load_options(self):
         self.dim_hour = int(self.get_option('Clock', 'dim', str(self.dim_hour)))


### PR DESCRIPTION
[First, kudos for a set of useful and entertaining samples!]

In Python 3.x, attempting to use the left/right touchpad buttons with the clock module would crash. E.g. when trying to toggle 'binary' mode in the clock.

This change addresses the crash by storing the plugin settings as strings. I'm not sure why this crash did not occur in Python 2.x ...

Here is the stack dump I received from the original code:
```
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.4/dist-packages/cap1xxx.py", line 217, in run
    if self.todo() == False:
  File "/usr/local/lib/python3.4/dist-packages/cap1xxx.py", line 443, in _poll
    self._handle_alert()
  File "/usr/local/lib/python3.4/dist-packages/cap1xxx.py", line 436, in _handle_alert
    self._trigger_handler(x, inputs[x])
  File "/usr/local/lib/python3.4/dist-packages/cap1xxx.py", line 452, in _trigger_handler
    self.handlers[event][channel](channel, event)
  File "/usr/local/lib/python3.4/dist-packages/dothat/touch.py", line 64, in handle_right
    menu.right()
  File "/usr/local/lib/python3.4/dist-packages/dot3k/menu.py", line 348, in right
    self.current_value().right()
  File "../../plugins/clock.py", line 81, in right
    self.update_options()
  File "../../plugins/clock.py", line 46, in update_options
    self.set_option('Clock', 'dim', self.dim_hour)
  File "/usr/local/lib/python3.4/dist-packages/dot3k/menu.py", line 557, in set_option
    self.config.set(section, option, value)
  File "/usr/lib/python3.4/configparser.py", line 1166, in set
    self._validate_value_types(option=option, value=value)
  File "/usr/lib/python3.4/configparser.py", line 1155, in _validate_value_types
    raise TypeError("option values must be strings")
TypeError: option values must be strings
```