### PR TITLE
Apply delay to repeats too, just like the description says

### DIFF
--- a/python/library/dot3k/joystick.py
+++ b/python/library/dot3k/joystick.py
@@ -62,9 +62,11 @@ def repeat(button, handler, delay=0.1, ramp=1.0):
     repeat_status[button] = True
     last_trigger = millis()
     while GPIO.input(button) == 0:
-        if millis() - last_trigger >= (delay * 1000):
+        m = millis()
+        if m - last_trigger >= (delay * 1000):
             handler()
             delay *= ramp
+            last_trigger = m
     repeat_status[button] = False
 
 


### PR DESCRIPTION
Hi,

I believe this is a bug as the delay was not applied to repeats, even though the description said so.

This will re-set the last_trigger every time a trigger happens. Otherwise the condition is always true after the first invocation and there are no further delays.
